### PR TITLE
activate account expiration with mas

### DIFF
--- a/synapse/api/auth/mas.py
+++ b/synapse/api/auth/mas.py
@@ -27,8 +27,8 @@ from pydantic import (
 
 from synapse.api.auth.base import BaseAuth
 from synapse.api.errors import (
-    Codes,#:tchap:
     AuthError,
+    Codes,  #:tchap:
     HttpResponseException,
     InvalidClientTokenError,
     SynapseError,
@@ -106,7 +106,7 @@ class MasDelegatedAuth(BaseAuth):
         self.server_name = hs.hostname
         self._clock = hs.get_clock()
         self._config = hs.config.mas
-        self._account_validity_handler = hs.get_account_validity_handler()#:tchap:
+        self._account_validity_handler = hs.get_account_validity_handler()  #:tchap:
 
         self._http_client = hs.get_proxied_http_client()
         self._rust_http_client = HttpClient(

--- a/synapse/api/auth/mas.py
+++ b/synapse/api/auth/mas.py
@@ -27,6 +27,7 @@ from pydantic import (
 
 from synapse.api.auth.base import BaseAuth
 from synapse.api.errors import (
+    Codes,#:tchap:
     AuthError,
     HttpResponseException,
     InvalidClientTokenError,
@@ -105,6 +106,7 @@ class MasDelegatedAuth(BaseAuth):
         self.server_name = hs.hostname
         self._clock = hs.get_clock()
         self._config = hs.config.mas
+        self._account_validity_handler = hs.get_account_validity_handler()#:tchap:
 
         self._http_client = hs.get_proxied_http_client()
         self._rust_http_client = HttpClient(
@@ -289,6 +291,22 @@ class MasDelegatedAuth(BaseAuth):
                     token=access_token,
                     allow_expired=allow_expired,
                 )
+
+                #:tchap:
+                # Deny the request if the user account has expired.
+                if not allow_expired:
+                    if await self._account_validity_handler.is_user_expired(
+                        requester.user.to_string()
+                    ):
+                        # Raise the error if either an account validity module has determined
+                        # the account has expired, or the legacy account validity
+                        # implementation is enabled and determined the account has expired
+                        raise AuthError(
+                            403,
+                            "User account has expired",
+                            errcode=Codes.EXPIRED_ACCOUNT,
+                        )
+                #:tchap: end
 
             await self._record_request(request, requester)
 

--- a/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
+++ b/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
@@ -290,8 +290,8 @@ class ThirdPartyEventRulesModuleApiCallbacks:
         # unable to create the event once it is frozen
         # quick fix, do not freeze the event before passing it to the external modules
         # not ideal but for tchap we control what we do in the module
-        # should
-        # event.freeze()
+        # should  
+        #event.freeze()
         #:tchap:end
 
         for callback in self._check_event_allowed_callbacks:

--- a/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
+++ b/synapse/module_api/callbacks/third_party_event_rules_callbacks.py
@@ -290,8 +290,8 @@ class ThirdPartyEventRulesModuleApiCallbacks:
         # unable to create the event once it is frozen
         # quick fix, do not freeze the event before passing it to the external modules
         # not ideal but for tchap we control what we do in the module
-        # should  
-        #event.freeze()
+        # should
+        # event.freeze()
         #:tchap:end
 
         for callback in self._check_event_allowed_callbacks:


### PR DESCRIPTION
When activtating MAS, the verification of account expiration is not executed anymore. 

This PR added previsou checks from `synapse/api/auth/internal.py`